### PR TITLE
improvements for 'kubectl logs -f'

### DIFF
--- a/charts/iperf3/templates/deployment.yml
+++ b/charts/iperf3/templates/deployment.yml
@@ -24,6 +24,8 @@ spec:
             - iperf3
             - -s
             - -p 40000
+            - -i 1
+            - --forceflush
           ports:
             - name: iperf3
               containerPort: 40000


### PR DESCRIPTION
add options so log output is flushed every second, i.e. it appears faster in 'kubectl logs some-pod-name -f'