### PR TITLE
iperf3: make image configurable

### DIFF
--- a/charts/iperf3/templates/deployment.yml
+++ b/charts/iperf3/templates/deployment.yml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: iperf3
-          image: networkstatic/iperf3
+          image: {{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}
           command:
             - iperf3
             - -s

--- a/charts/iperf3/values.yaml
+++ b/charts/iperf3/values.yaml
@@ -8,3 +8,9 @@ service:
 verbose: false
 # change this to set the number of replicas
 replicas: 1
+deployment:
+  image:
+    # if needed you can use another image
+    repository: networkstatic/iperf3
+    # adapt if you want to use a different tag
+    tag: "latest"


### PR DESCRIPTION
The `networkstatic/iperf3` image does not work on arm machines like e.g. a Raspi 4:

```
standard_init_linux.go:228: exec user process caused: exec format error
```

So, this PR makes the image configurable.