### PR TITLE
Added option to create a serviceacount

### DIFF
--- a/charts/rundeck/templates/nginx-deployment.yaml
+++ b/charts/rundeck/templates/nginx-deployment.yaml
@@ -55,6 +55,7 @@ spec:
           volumeMounts:
             - name: nginx-config
               mountPath: /etc/nginx
+      serviceAccountName: {{ include "rundeck.serviceAccountName" . }}
       volumes:
         - name: nginx-config
           configMap:

--- a/charts/rundeck/templates/rundeck-backend-deployment.yaml
+++ b/charts/rundeck/templates/rundeck-backend-deployment.yaml
@@ -165,6 +165,8 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.image.pullSecrets }}
       {{- end }}
+      
+      serviceAccountName: {{ include "rundeck.serviceAccountName" . }}
 
       volumes:
         - name: boostrap-wrapper-script

--- a/charts/rundeck/templates/serviceaccount.yaml
+++ b/charts/rundeck/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/rundeck/templates/serviceaccount.yaml
+++ b/charts/rundeck/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "rundeck.serviceAccountName" . }}
+  labels:
+    {{- include "rundeck.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/rundeck/values.yaml
+++ b/charts/rundeck/values.yaml
@@ -195,7 +195,7 @@ sideCars:
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: true
+  enabled: false
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/rundeck/values.yaml
+++ b/charts/rundeck/values.yaml
@@ -192,3 +192,12 @@ sideCars:
   #     - "-instances=<instance_end_point>=tcp:3306"
   #   securityContext:
   #     runAsNonRoot: true
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""


### PR DESCRIPTION
Using a ServiceAccount can be useful when running a cluster that doesn't allow containers to be run as root. Then you can bind the ServiceAccount of this deployment to a new psp (or similar) to allow running as root.