### PR TITLE
Remove duplicated ports attribute

### DIFF
--- a/charts/rundeck/templates/rundeck-backend-deployment.yaml
+++ b/charts/rundeck/templates/rundeck-backend-deployment.yaml
@@ -122,9 +122,6 @@ spec:
           - name: framework-append
             mountPath: /home/rundeck/custom/framework
           {{- end }}          
-          ports:
-            - name: rundeck
-              containerPort: 4440
           livenessProbe:
             httpGet:  
               path: /


### PR DESCRIPTION
I was trying to set Rundeck up in a new environment using Helm 3.8.2 with your chart, got a duplicated keys error and after inspecting the templates I found ports was duplicated

Not a helm expert myself so not sure if helm silently errored these in older versions but I guess this is a bug anyway?