### PR TITLE
Add h2 internal database for rundeck (for development)

### DIFF
--- a/charts/rundeck/Chart.yaml
+++ b/charts/rundeck/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Rundeck chart for Kubernetes
 name: rundeck
 home: https://github.com/rundeck/rundeck
-version: 1.4.0
+version: 1.4.1
 appVersion: 4.10.0
 keywords:
   - rundeck

--- a/charts/rundeck/Chart.yaml
+++ b/charts/rundeck/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Rundeck chart for Kubernetes
 name: rundeck
 home: https://github.com/rundeck/rundeck
-version: 1.4.1
+version: 1.5.0
 appVersion: 4.10.0
 keywords:
   - rundeck

--- a/charts/rundeck/README.md
+++ b/charts/rundeck/README.md
@@ -50,8 +50,6 @@ Please open or ask all those questions in one of the [official channels](https:/
 
 ## Database
 
-For development usage, the `h2DevelopmentStorage` flag can be set to true, in which case rundeck will use the embedded database at `jdbc:h2:file:/home/rundeck/server/data/grailsdb;MVCC=true`. This is only meant for pure development and testing, never use on a production environment (see [docs for default](https://docs.rundeck.com/docs/administration/configuration/docker.html#basic) and [database docs](https://docs.rundeck.com/docs/administration/configuration/docker.html#basic)).
-
 For production usage, the secret `database.secret_name` must include the following keys
 
 - `jdbc`: The jdbc url like `jdbc:postgresql://$user:$password@$host:$port/$database`
@@ -60,6 +58,8 @@ For production usage, the secret `database.secret_name` must include the followi
 - `type`: one of these `org.postgresql.Driver`/`org.mariadb.jdbc.Driver`/`com.mysql.jdbc.Driver`
 
 See the [docs](https://docs.rundeck.com/docs/administration/configuration/docker.html#database)
+
+For development usage, the `h2DevelopmentStorage` flag can be set to true, in which case rundeck will use the embedded database at `jdbc:h2:file:/home/rundeck/server/data/grailsdb;MVCC=true`. This is only meant for pure development and testing, never use on a production environment (see [docs for default](https://docs.rundeck.com/docs/administration/configuration/docker.html#basic) and [database docs](https://docs.rundeck.com/docs/administration/configuration/docker.html#basic)).
 
 ## Execution logs
 

--- a/charts/rundeck/README.md
+++ b/charts/rundeck/README.md
@@ -45,12 +45,14 @@ Please open or ask all those questions in one of the [official channels](https:/
 - deploy your `user-credentials-secret` secret (in your rundeck namespace) with the field `userCredentials` including the string (at least)`admin:PASSWORD,user,admin,architect,deploy,build`
   - replace `PASSWORD` with your password
   - add as many as you like, seperate by newlines `\n`
-- deploy your `rundeck-database-secret` to define the DB credentials and connection details. See `Database` below.
+- deploy your `rundeck-database-secret` to define the DB credentials and connection details or use `h2DevelopmentStorage` (only for non-production). See `Database` below.
 - deploy your own `ingress` route (default) or activate `ingress.enabled` and set the values to your liking
 
 ## Database
 
-The secret `database.secret_name` must include the following keys
+For development usage, the `h2DevelopmentStorage` flag can be set to true, in which case rundeck will use the embedded database at `jdbc:h2:file:/home/rundeck/server/data/grailsdb;MVCC=true`. This is only meant for pure development and testing, never use on a production environment (see [docs for default](https://docs.rundeck.com/docs/administration/configuration/docker.html#basic) and [database docs](https://docs.rundeck.com/docs/administration/configuration/docker.html#basic)).
+
+For production usage, the secret `database.secret_name` must include the following keys
 
 - `jdbc`: The jdbc url like `jdbc:postgresql://$user:$password@$host:$port/$database`
 - `user`: DB user

--- a/charts/rundeck/README.md
+++ b/charts/rundeck/README.md
@@ -45,7 +45,7 @@ Please open or ask all those questions in one of the [official channels](https:/
 - deploy your `user-credentials-secret` secret (in your rundeck namespace) with the field `userCredentials` including the string (at least)`admin:PASSWORD,user,admin,architect,deploy,build`
   - replace `PASSWORD` with your password
   - add as many as you like, seperate by newlines `\n`
-- deploy your `rundeck-database-secret` to define the DB credentials and connection details or use `useInternalH2db` (only for non-production). See `Database` below.
+- deploy your `rundeck-database-secret` to define the DB credentials and connection details or use `database.useInternalH2db` (only for non-production). See `Database` below.
 - deploy your own `ingress` route (default) or activate `ingress.enabled` and set the values to your liking
 
 ## Database
@@ -59,7 +59,7 @@ For production usage, the secret `database.secret_name` must include the followi
 
 See the [docs](https://docs.rundeck.com/docs/administration/configuration/docker.html#database)
 
-For development usage, the `useInternalH2db` flag can be set to true, in which case rundeck will use the embedded database at `jdbc:h2:file:/home/rundeck/server/data/grailsdb;MVCC=true`. This is only meant for pure development and testing, never use on a production environment (see [docs for default](https://docs.rundeck.com/docs/administration/configuration/docker.html#basic) and [database docs](https://docs.rundeck.com/docs/administration/configuration/docker.html#basic)).
+For development usage, the `database.useInternalH2db` flag can be set to true, in which case rundeck will use the embedded database at `jdbc:h2:file:/home/rundeck/server/data/grailsdb;MVCC=true`. This is only meant for pure development and testing, never use on a production environment (see [docs for default](https://docs.rundeck.com/docs/administration/configuration/docker.html#basic) and [database docs](https://docs.rundeck.com/docs/administration/configuration/docker.html#basic)).
 
 ## Execution logs
 

--- a/charts/rundeck/README.md
+++ b/charts/rundeck/README.md
@@ -45,7 +45,7 @@ Please open or ask all those questions in one of the [official channels](https:/
 - deploy your `user-credentials-secret` secret (in your rundeck namespace) with the field `userCredentials` including the string (at least)`admin:PASSWORD,user,admin,architect,deploy,build`
   - replace `PASSWORD` with your password
   - add as many as you like, seperate by newlines `\n`
-- deploy your `rundeck-database-secret` to define the DB credentials and connection details or use `h2DevelopmentStorage` (only for non-production). See `Database` below.
+- deploy your `rundeck-database-secret` to define the DB credentials and connection details or use `useInternalH2db` (only for non-production). See `Database` below.
 - deploy your own `ingress` route (default) or activate `ingress.enabled` and set the values to your liking
 
 ## Database
@@ -59,7 +59,7 @@ For production usage, the secret `database.secret_name` must include the followi
 
 See the [docs](https://docs.rundeck.com/docs/administration/configuration/docker.html#database)
 
-For development usage, the `h2DevelopmentStorage` flag can be set to true, in which case rundeck will use the embedded database at `jdbc:h2:file:/home/rundeck/server/data/grailsdb;MVCC=true`. This is only meant for pure development and testing, never use on a production environment (see [docs for default](https://docs.rundeck.com/docs/administration/configuration/docker.html#basic) and [database docs](https://docs.rundeck.com/docs/administration/configuration/docker.html#basic)).
+For development usage, the `useInternalH2db` flag can be set to true, in which case rundeck will use the embedded database at `jdbc:h2:file:/home/rundeck/server/data/grailsdb;MVCC=true`. This is only meant for pure development and testing, never use on a production environment (see [docs for default](https://docs.rundeck.com/docs/administration/configuration/docker.html#basic) and [database docs](https://docs.rundeck.com/docs/administration/configuration/docker.html#basic)).
 
 ## Execution logs
 

--- a/charts/rundeck/templates/rundeck-backend-deployment.yaml
+++ b/charts/rundeck/templates/rundeck-backend-deployment.yaml
@@ -52,6 +52,7 @@ spec:
               containerPort: 4440
               protocol: TCP
           env:
+          {{- if not .Values.rundeck.h2DevelopmentStorage }}
             - name: RUNDECK_DATABASE_DRIVER
               valueFrom:
                 secretKeyRef:
@@ -71,7 +72,8 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{.Values.database.secret_name| quote }}
-                  key: password                                 
+                  key: password
+            {{- end }}
             - name: RUNDECK_GRAILS_URL
               value: {{ required "Please set the externUrl so grails can be configured!" .Values.externUrl | quote }}                     
           volumeMounts:

--- a/charts/rundeck/templates/rundeck-backend-deployment.yaml
+++ b/charts/rundeck/templates/rundeck-backend-deployment.yaml
@@ -52,7 +52,7 @@ spec:
               containerPort: 4440
               protocol: TCP
           env:
-          {{- if not .Values.rundeck.h2DevelopmentStorage }}
+          {{- if not .Values.rundeck.useInternalH2db }}
             - name: RUNDECK_DATABASE_DRIVER
               valueFrom:
                 secretKeyRef:

--- a/charts/rundeck/templates/rundeck-backend-deployment.yaml
+++ b/charts/rundeck/templates/rundeck-backend-deployment.yaml
@@ -52,7 +52,7 @@ spec:
               containerPort: 4440
               protocol: TCP
           env:
-          {{- if not .Values.rundeck.useInternalH2db }}
+          {{- if not .Values.database.useInternalH2db }}
             - name: RUNDECK_DATABASE_DRIVER
               valueFrom:
                 secretKeyRef:

--- a/charts/rundeck/values.yaml
+++ b/charts/rundeck/values.yaml
@@ -92,6 +92,7 @@ rundeck:
   rundeckFrameworkConfigMap:
   # Create this secrete in the rundeck namespace.
   # Should have the field `userCredentials` with the value `admin:YOURPASSWORD,user,admin,architect,deploy,build`
+  h2DevelopmentStorage: false
   userCredentialsSecretName: user-credentials-secret
   env:
     # @see https://docs.rundeck.com/docs/administration/configuration/docker.html#environment-variables for the options

--- a/charts/rundeck/values.yaml
+++ b/charts/rundeck/values.yaml
@@ -44,6 +44,9 @@ database:
   # A secret including the following keys `type`,`jdbc`,`port`,`user`,`password`,`database`
   # type can be postgresql/mysql and so forth. Should be in the same namespace as you deploy the helm chart
   secret_name: rundeck-database-secret
+  # If set to true, the chart won't consider the secret above for configuration and will default back to rundeck own defaults. Not safe for production.
+  # @see https://github.com/EugenMayer/helm-charts/tree/main/charts/rundeck#database
+  useInternalH2db: false
 
 securityContext:
   # keep those settings until you really know what you are doing here
@@ -92,7 +95,6 @@ rundeck:
   rundeckFrameworkConfigMap:
   # Create this secrete in the rundeck namespace.
   # Should have the field `userCredentials` with the value `admin:YOURPASSWORD,user,admin,architect,deploy,build`
-  h2DevelopmentStorage: false
   userCredentialsSecretName: user-credentials-secret
   env:
     # @see https://docs.rundeck.com/docs/administration/configuration/docker.html#environment-variables for the options


### PR DESCRIPTION
Hello,

I wanted to propose the possibility to use the H2 embedded database that comes bundled within rundeck.
I am totally aware that it is non-recommended for production use, nonetheless, I believe that a `helm` chart should include a way to deploy something with no external dependencies (when technically possible), for testing purpose, and to confirm the chart behaves as expected.

I want to run tests on volatile rundecks, that I can throw and re-use without managing anything external until it becomes production ready.

My proposal is to enable a feature flag (`false` by default) named `h2DevelopmentStorage`. The presence of the flag deactivates the `ENV` variables that refer to the `rundeck-database-secret`, bringing rundeck to the default behavior of using h2 at `jdbc:h2:file:/home/rundeck/server/data/grailsdb;MVCC=true` as specified in the docs.

Let me know what you think of it.

I am actively using it on multiple rundecks with no issue.