### PR TITLE
Make subPath for user credentials configurable

### DIFF
--- a/charts/rundeck/templates/rundeck-backend-deployment.yaml
+++ b/charts/rundeck/templates/rundeck-backend-deployment.yaml
@@ -114,7 +114,7 @@ spec:
           {{- if .Values.rundeck.userCredentialsSecretName }}
           - name: user-credentials
             mountPath: /home/rundeck/server/config/realm.properties
-            subPath: userCredentials
+            subPath: {{ .Values.rundeck.userCredentialsSecretSubpath }}
           {{- end }}
           {{- if .Values.rundeck.rundeckConfigConfigMap }}
           - name: rundeck-config-append

--- a/charts/rundeck/values.yaml
+++ b/charts/rundeck/values.yaml
@@ -96,6 +96,8 @@ rundeck:
   # Create this secrete in the rundeck namespace.
   # Should have the field `userCredentials` with the value `admin:YOURPASSWORD,user,admin,architect,deploy,build`
   userCredentialsSecretName: user-credentials-secret
+  # Name of the field within the user credentials secret that contains the actual credentials
+  userCredentialsSecretSubpath: userCredentials
   env:
     # @see https://docs.rundeck.com/docs/administration/configuration/docker.html#environment-variables for the options
     RUNDECK_SERVER_FORWARDED: "true"


### PR DESCRIPTION
Hi!

Thanks for your work on taking over this old incubator chart. I was working on upgrading our old Rundeck install the last few days and while doing that also migrated to your chart.

We're using https://github.com/mumoshu/aws-secret-operator to handle our AWS secrets and as we maintain the users as a string secret their resulting `Secret` in Kubernetes has the field `data` not `userCredentials`.

I can work around that by base64-encoding the contents and storing it with that field as a key/value pair but that seemed overkill so I made the name of the field in the secret to mount as subpath configurable.