### PR TITLE
Resilient bootstrap when no custom plugins exist

### DIFF
--- a/charts/rundeck/scripts/bootstrap.sh
+++ b/charts/rundeck/scripts/bootstrap.sh
@@ -17,8 +17,12 @@ if test -f "$FRAMEWORK_SRC"; then
     cp "$FRAMEWORK_SRC" /tmp/remco-partials/framework/framework-custom.properties
 fi
 
-echo "Copying custom plugins"
-cp -r /mnt/plugins/. /home/rundeck/libext
+if test -d /mnt/plugins; then
+    echo "Copying custom plugins"
+    cp -r /mnt/plugins/. /home/rundeck/libext
+else
+    echo "Starting without custom plugins because mount point '/mnt/plugins' does not exist"
+fi
 
 echo "Continue with common bootstrap"
 exec /home/rundeck/docker-lib/entry.sh


### PR DESCRIPTION
It's allowed to run the chart without the plugins claim (`.Values.plugins.claim.enabled: false`) and then it subsequently also does not create the volume mounts which works fine.

But during startup the bootstrap script will try to copy files from `/mnt/plugins` which does not exist and then fails the startup.

This seemed like the simplest solution to me.