### PR TITLE
Added sideCars to Rundeck helm chart deployment template

### DIFF
--- a/charts/rundeck/templates/rundeck-backend-deployment.yaml
+++ b/charts/rundeck/templates/rundeck-backend-deployment.yaml
@@ -140,6 +140,9 @@ spec:
             periodSeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.sideCars }}
+          {{- toYaml .Values.sideCars | nindent 8 }}
+        {{- end }}
       {{- if .Values.nodeSelector }}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
As per issue https://github.com/EugenMayer/helm-charts/issues/50 the readme for the Rundeck helm chart currently states that the sideCars value can be used to run additional containers in the Rundeck pod, however although it is mentioned in the chart readme and a commented out example exists in the [values](https://github.com/EugenMayer/helm-charts/blob/main/charts/rundeck/values.yaml#L200) file it isn't actually applied by the deployment template.

This change therefore re-adds the sideCars into the Rundeck deployment template to allow sidecar containers (such as the rundeck-exporter for monitoring purposes) to be deployed via the Rundeck chart.