### PR TITLE
Updated service name to use template var

### DIFF
--- a/charts/rundeck/templates/nginx-service.yaml
+++ b/charts/rundeck/templates/nginx-service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: rundeck-nginx
+  name: {{ $fullName }}-nginx
   labels: {{ include "rundeck.labels" . | indent 4 }}
 spec:
   type: ClusterIP


### PR DESCRIPTION
If a custom name is used on install, there is a mismatch issue between the Ingress and the Service it refers to.

Previously, this install command would result in a broken Ingress:
`helm install my-cool-rundeck eugenmayer/rundeck`
The Ingress would refer to the service "my-cool-rundeck-nginx", but the Service would be named "rundeck-nginx".

Using the template variable fixes this.