### PR TITLE
feat: bump vulnz-nvd-mirror version to 7.0.2

### DIFF
--- a/charts/vulnz-nvd-mirror/CHANGELOG.md
+++ b/charts/vulnz-nvd-mirror/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.4.1
 
 - upgrade vulnz to 7.0.2
-- remove predefined JAVA_OPT settings
+- remove predefined JAVA_OPT settings, set default memory limit instead
 
 ## 0.4.0
 

--- a/charts/vulnz-nvd-mirror/CHANGELOG.md
+++ b/charts/vulnz-nvd-mirror/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.1
+
+- upgrade vulnz to 7.0.2
+- remove predefined JAVA_OPT settings
+
 ## 0.4.0
 
 - adjust mounted PVC permissions to match app's user

--- a/charts/vulnz-nvd-mirror/Chart.yaml
+++ b/charts/vulnz-nvd-mirror/Chart.yaml
@@ -1,8 +1,8 @@
 kubeVersion: ">=1.24.0-0"
 apiVersion: v2
 name: vulnz-nvd-mirror
-version: 0.4.0
-appVersion: 7.0.1
+version: 0.4.1
+appVersion: 7.0.2
 description: NVD api mirror and cache
 home: https://github.com/EugenMayer/helm-charts/tree/main/charts/vulnz-nvd-mirror
 deprecated: false

--- a/charts/vulnz-nvd-mirror/values.yaml
+++ b/charts/vulnz-nvd-mirror/values.yaml
@@ -50,6 +50,10 @@ workload:
                 periodSeconds: 5
                 failureThreshold: 2
 
+          resources:
+            limits:
+              memory: 2Gi
+
           # env:
           #   # set this to preseed your API key. the expected structure is
           #   NVD_API_KEY:

--- a/charts/vulnz-nvd-mirror/values.yaml
+++ b/charts/vulnz-nvd-mirror/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/jeremylong/open-vulnerability-data-mirror
-  tag: v7.0.1
+  tag: v7.0.2
   pullPolicy: IfNotPresent
 
 persistence:
@@ -33,20 +33,6 @@ workload:
     podSpec:
       containers:
         main:
-          env:
-            # set this to preseed your API key. the expected structure is
-            #NVD_API_KEY:
-            #  secretKeyRef:
-            #    name: nvd-api-key
-            #    key: password
-            JAVA_OPT: -Xmx2g
-            # amount of retries
-            #MAX_RETRY: 10
-            # fetch max record pre page - cannot be higher then 2000 by API limits
-            #MAX_RECORDS_PER_PAGE: 2000
-            # show debug logs
-            #DEBUG: true
-
           probes:
             readiness:
               port: 80
@@ -63,6 +49,19 @@ workload:
                 initialDelaySeconds: 15
                 periodSeconds: 5
                 failureThreshold: 2
+
+          # env:
+          #   # set this to preseed your API key. the expected structure is
+          #   NVD_API_KEY:
+          #     secretKeyRef:
+          #       name: nvd-api-key
+          #       key: password
+          #   # amount of retries
+          #   MAX_RETRY: 10
+          #   # fetch max record pre page - cannot be higher then 2000 by API limits
+          #   MAX_RECORDS_PER_PAGE: 2000
+          #   # show debug logs
+          #   DEBUG: true
 
 ingress:
   main:


### PR DESCRIPTION
remove predefined JAVA_OPT memory allocation setting (ref: https://github.com/jeremylong/Open-Vulnerability-Project/pull/224)